### PR TITLE
Tweaks for running on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ backup/
 *.pdf
 # python cache
 __pycache__/
-
-
-
-
+venv/
+# ides
+.vscode/
+.idea/

--- a/BitNetMCU_MNIST_dll.c
+++ b/BitNetMCU_MNIST_dll.c
@@ -13,8 +13,15 @@
  * @return The result of the inference.
  */
 
+uint32_t BitMnistInference(int8_t *input);
+
 #ifdef _DLL
-__declspec(dllexport) uint32_t Inference(int8_t *input) {
+#ifdef WIN32
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT __attribute__((visibility("default")))
+#endif
+EXPORT uint32_t Inference(int8_t *input) {
     return BitMnistInference(input);
 }
 #endif

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+SOURCES = BitNetMCU_MNIST_dll.c BitNetMCU_inference.c
+HEADERS = BitNetMCU_model.h  BitNetMCU_inference.h
+DLL = Bitnet_inf.dll
+
+$(DLL): $(SOURCES) $(HEADERS)
+	cc -fPIC -shared -o $@ -D _DLL $<
+
+.PHONY: clean
+clean:
+	rm -f $(DLL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ torch
 torchvision
 numpy
 PyYAML
+tensorboard
+matplotlib


### PR DESCRIPTION
This commit contains a number of tweaks to ensure exporting quantization and testing inference both work on Linux-based setups.

* `exportquant.py`: made `np.uint32` data type explicit -- on some configurations, the type `int` appears to be bridged by `numpy` into `np.int64`, so when the weights are packed, they're packed into 8 bytes instead of 4, and when the view is converted to `np.uint32` every other entry is just `0x00000000`.
* `BitNetMCU_MNIST_dll.c`: added forward declaration for `BitMnistInference` and a guard for `__declspec` (not supported by gcc)
* `requirements.txt`: Added tensorboard, matplotlib
* Created `Makefile` for compilation on Linux